### PR TITLE
feat: Show ignore status for fully ignored directories.

### DIFF
--- a/lua/lir/git_status/git.lua
+++ b/lua/lir/git_status/git.lua
@@ -74,8 +74,9 @@ end)
 
 --- cwd の git status を返す
 ---@param cwd string
+---@param paths string[]
 ---@return table
-M.get_status = async(function(cwd)
+M.get_status = async(function(cwd, paths)
   local args = {
     'status',
     '--porcelain',
@@ -83,7 +84,14 @@ M.get_status = async(function(cwd)
   }
 
   if config.get('show_ignored') then
-    table.insert(args, '--ignored')
+    table.insert(args, '--ignored=matching')
+  end
+
+  if type(paths) == 'table' then
+    args[#args+1] = '--'
+    for _, path in ipairs(paths) do
+      args[#args+1] = path
+    end
   end
 
   local err, res = await(command({


### PR DESCRIPTION
This change gives fully ignored directories the appropriate `[!!]`
status. The way it works currently, ignored directories and directories
with one or more ignored files, get the `[ -]` status. This indicates to
me that something requires my attention, which is not really the case
with ignored files.

This also slightly changes the conditions for when a directory gets a
status:

- Directories that are fully ignored (they are matched by an ignore
  pattern, and all contents are ignored) get the `[!!]` status.
- Directories that only contain one or more ignored files ***don't***
  get a status at all (currently these get the `[ -]` status). I prefer
  it this way, because one doesn't really need to know what directories
  contain *some* ignored files. But I can change this back if you prefer
  the current approach.
- All other cases are the same.

Other changes:
- (perf) Only get git status for the cwd rather than the entire
  worktree every time.
- (fix) Directories with a git status previously always had the 'their'
  side of the status highlighted regardless of whether or not there were
  any changes on 'their' side.

![image](https://user-images.githubusercontent.com/2786478/144857818-8c35b405-e28b-474a-b081-92df6c260d76.png)