### PR TITLE
feat: Add the git-status to the lir file context.

### DIFF
--- a/doc/lir_git_status.txt
+++ b/doc/lir_git_status.txt
@@ -19,6 +19,17 @@ lir.git_status.setup([{opts}])                        *lir.git_status.setup()*
    Please see |lir-git-status-settings|.
 
 ------------------------------------------------------------------------------
+LIR-GIT-STATUS-CONTEXT                                *lir-git-status-context*
+
+The |lir-context| tables are extended to contain additional data from git.
+
+context.git                                       *lir-git-status-context-git*
+    Git data.
+
+context.git.toplevel                     *lir-git-status-context-git-toplevel*
+    The path to the top-level directory of the working tree.
+
+------------------------------------------------------------------------------
 LIR-GIT-STATUS-FILE-ITEM                            *lir-git-status-file-item*
 
 The |lir-file-item| tables in the lir context are extended to contain
@@ -31,7 +42,7 @@ git.status                     *lir-git-status-file-item-attribute-git-status*
     If the file has a git status, this will be a two char string of git status
     symbols. The symbols can be one of: 
 
-    `A`, `?`, `M`, `R`, `C`, `T`, `U`, `X`, `D`, `B`, `-`
+    `A`, `M`, `R`, `C`, `T`, `U`, `X`, `D`, `B`, `?`, `!`, `-`
 
     See `:Man git-status(1)` for the definition of the different symbols. The
     special symbol "`-`" is used for directories that contain one or more

--- a/doc/lir_git_status.txt
+++ b/doc/lir_git_status.txt
@@ -18,6 +18,24 @@ lir.git_status.setup([{opts}])                        *lir.git_status.setup()*
    Set up the lir.
    Please see |lir-git-status-settings|.
 
+------------------------------------------------------------------------------
+LIR-GIT-STATUS-FILE-ITEM                            *lir-git-status-file-item*
+
+The |lir-file-item| tables in the lir context are extended to contain
+additional data from git.
+
+git                                   *lir-git-status-file-item-attribute-git*
+   Git data.
+
+git.status                     *lir-git-status-file-item-attribute-git-status*
+    If the file has a git status, this will be a two char string of git status
+    symbols. The symbols can be one of: 
+
+    `A`, `?`, `M`, `R`, `C`, `T`, `U`, `X`, `D`, `B`, `-`
+
+    See `:Man git-status(1)` for the definition of the different symbols. The
+    special symbol "`-`" is used for directories that contain one or more
+    files with a git status.
 
 ==============================================================================
 SETTINGS                                             *lir-git-status-settings*

--- a/lua/lir/git_status.lua
+++ b/lua/lir/git_status.lua
@@ -93,6 +93,9 @@ M.refresh = async_void(function()
     return
   end
 
+  ctx.git = ctx.git or {}
+  ctx.git.toplevel = root
+
   -- root からの cwd の パス
   local rel_cwd = cwd:sub(#root+2)
 

--- a/lua/lir/git_status.lua
+++ b/lua/lir/git_status.lua
@@ -98,8 +98,9 @@ M.refresh = async_void(function()
 
   -- 完了したディレクトリのリスト
   local dirs = {}
-  for i = 1, #ctx.files do
-    dirs[i] = {}
+  for i, entry in ipairs(ctx.files) do
+    entry.git = entry.git or {}
+    dirs[i] = { entry = entry }
   end
 
   local all_ignored = false
@@ -138,6 +139,7 @@ M.refresh = async_void(function()
     if not ctx.files[lnum].is_dir or (exact_match and status == '!!') then
       local us = status:sub(1, 1)
       local them = status:sub(2, 2)
+      ctx.files[lnum].git.status = us .. them
       await(set_virtual_text(bufnr, lnum, us, them))
 
     else
@@ -178,6 +180,7 @@ M.refresh = async_void(function()
     end
 
     if us ~= ' ' or them ~= ' ' then
+      status.entry.git.status = us .. them
       await(set_virtual_text(bufnr, lnum, us, them))
     end
   end


### PR DESCRIPTION
This adds data with the git-status symbol to the file context. This way that information can be utilized in custom actions etc.

The new data can be accessed like so:

```lua
local ctx = require("lir").get_context()
local cur = ctx:current()
vim.pretty_print(ctx.git)
vim.pretty_print(cur.git)
```

Example output:

```
{
  toplevel = "/foo/bar/baz"
}

{
  status = "AM"
}
```

`toplevel` is the path to the top-level directory of the working tree.

`status` will be a `nil` value for files that don't have a git status.
