### PR TITLE
perf: Exclude all subdirectories from git-status

### DIFF
--- a/lua/lir/git_status.lua
+++ b/lua/lir/git_status.lua
@@ -7,6 +7,7 @@ local config = require'lir.git_status.config'
 local git = require'lir.git_status.git'
 local Path = require('plenary.path')
 
+local fmt = string.format
 local sep = Path.path.sep
 
 local M = {}
@@ -88,7 +89,7 @@ M.refresh = async_void(function()
     return
   end
 
-  local results = await(git.get_status(root, { cwd }))
+  local results = await(git.get_status(root, { cwd, fmt(":!%s/*/*", cwd) }))
   if results == nil then
     return
   end


### PR DESCRIPTION
Currently we are running `git-status` on the current directory as well as all subdirectories. It occurred to me that we can use git-pathspec to exclude all subdirectories like so:

```console
$ git status -- some/example/dir ':!some/example/dir/*/*'
```

This way git will *only* check the status of the items in `some/example/dir`.
